### PR TITLE
Updated --gpos to resolve the GPO name and the gpcfilesyspath

### DIFF
--- a/Cable/Modules/ArgParse.cs
+++ b/Cable/Modules/ArgParse.cs
@@ -33,6 +33,7 @@ namespace Cable.Modules
                 "\t--computers               - Enumerate computer objects\n" +
                 "\t--groups                  - Enumerate group objects\n" +
                 "\t--gpos                    - Enumerate Group Policy objects\n" +
+                "\t--ous                     - Enumerate Organizational Units\n" +
                 "\t--spns                    - Enumerate objects with servicePrincipalName set\n" +
                 "\t--asrep                   - Enumerate accounts that do not require Kerberos pre-authentication\n" +
                 "\t--admins                  - Enumerate accounts with adminCount set to 1\n" +
@@ -152,7 +153,7 @@ namespace Cable.Modules
                                 string selection = null;
                                 List<string> attributes = new List<string>() { "samaccountname", "objectsid", "distinguishedname" };
                                 string[] enumFlags = { "--query", "--filter" };
-                                string[] enumOptions = { "--users", "--computers", "--groups", "--gpos", "--spns", "--asrep", "--admins", "--unconstrained", "--constrained", "--rbcd"};
+                                string[] enumOptions = { "--users", "--computers", "--groups", "--gpos", "--ous", "--spns", "--asrep", "--admins", "--unconstrained", "--constrained", "--rbcd"};
 
                                 Dictionary<string, string> enumcmd = Parse(args, enumFlags, enumOptions);
                                 if(enumcmd == null)

--- a/Cable/Modules/Enumerate.cs
+++ b/Cable/Modules/Enumerate.cs
@@ -1,12 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
 using System.DirectoryServices.ActiveDirectory;
-using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cable.Modules
 {
@@ -55,7 +52,23 @@ namespace Cable.Modules
 
             foreach (SearchResult sr in results)
             {
+                // Print the object name
                 Console.WriteLine("[+] Found object: " + sr.Properties["name"][0]);
+
+                // Check if the type is --gpos and print the GPO specific attributes
+                if (type == "--gpos")
+                {
+                    if (sr.Properties.Contains("displayName"))
+                    {
+                        Console.WriteLine("\t|__ GPO Name: " + sr.Properties["displayName"][0]);
+                    }
+                    if (sr.Properties.Contains("gPCFileSysPath"))
+                    {
+                        Console.WriteLine("\t|__ GPC File System Path: " + sr.Properties["gPCFileSysPath"][0]);
+                    }
+                }
+
+                // Now print additional attributes if they exist
                 foreach (string attribute in attributes)
                 {
                     if (sr.Properties.Contains(attribute))
@@ -82,7 +95,7 @@ namespace Cable.Modules
                         else
                         {
                             Console.Write("\t|__ " + attribute + ":\n");
-                            foreach(var value in sr.Properties[attribute])
+                            foreach (var value in sr.Properties[attribute])
                             {
                                 Console.WriteLine("\t|    |__ " + value.ToString());
                             }
@@ -91,7 +104,6 @@ namespace Cable.Modules
                 }
                 Console.Write("\n");
             }
-
         }
 
         public static void Dclist()
@@ -134,7 +146,7 @@ namespace Cable.Modules
             TrustRelationshipInformationCollection dtrusts = domain.GetAllTrustRelationships();
 
             Console.WriteLine("[+] Enumerating Domain trusts");
-            if(dtrusts.Count > 0)
+            if (dtrusts.Count > 0)
             {
                 foreach (TrustRelationshipInformation trust in dtrusts)
                 {
@@ -152,6 +164,5 @@ namespace Cable.Modules
             }
 
         }
-
     }
 }

--- a/Cable/Modules/Enumerate.cs
+++ b/Cable/Modules/Enumerate.cs
@@ -93,7 +93,7 @@ namespace Cable.Modules
                                                                                                             // Console.WriteLine($"\t|    [DEBUG] LDAP Query: {ldapQuery}"); // DEBUG
 
                                 // Perform LDAP query
-                                DirectoryEntry gpoDe = new DirectoryEntry("LDAP://DC=testlab,DC=local");
+                                DirectoryEntry gpoDe = new DirectoryEntry();
                                 DirectorySearcher gpoDs = new DirectorySearcher(gpoDe)
                                 {
                                     Filter = ldapQuery,


### PR DESCRIPTION
I updated the --gpos ldap command to print out the different properties of the GPO to make it easier to work with and understand what each GPO is for and where its at
Before:
![before](https://github.com/user-attachments/assets/bdd8e0dc-7e18-408a-b8f3-9d32a922a202)

After:
![after](https://github.com/user-attachments/assets/b9df5f3f-03fc-4236-90fd-1ee979df5ef8)

I also just added a --ous option to enumerate OUs and view their linked GPOs

![image](https://github.com/user-attachments/assets/c706d6b4-a547-4245-8d0f-87e7a317bbe9)
